### PR TITLE
[frontend] Adicionando as páginas de Unidade (Criação/Leitura)

### DIFF
--- a/frontend/app/(authed)/admin/unit/create/page.tsx
+++ b/frontend/app/(authed)/admin/unit/create/page.tsx
@@ -1,8 +1,6 @@
+import { Button } from "@/lib/components/button";
+import { InputField } from "@/lib/components/input";
 import { twMerge } from "tailwind-merge";
-
-function InputField({ className, ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
-  return <input className={twMerge(className, "bg-gray-300 text-black py-1 px-3 rounded-sm w-full text-lg")} {...props} />
-}
 
 export default function UnitCreatePage() {
   const onUnitCreate = async (form: FormData) => {
@@ -25,9 +23,9 @@ export default function UnitCreatePage() {
         <InputField name="name" id="name" type="text" placeholder="-" />
       </label>
 
-      <button type="submit" className="bg-black text-white px-5 py-1 mt-3">
+      <Button type="submit">
         Cadastrar
-      </button>
+      </Button>
     </form>
   )
 }

--- a/frontend/app/(authed)/admin/unit/view/page.tsx
+++ b/frontend/app/(authed)/admin/unit/view/page.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Unit } from "@/lib/schemas/unit";
+import { Endpoint } from "@/lib/services/endpoint";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { usePathname, useSearchParams, useRouter } from "next/navigation";
+import { FormEvent, useCallback } from "react";
+import { twMerge } from "tailwind-merge";
+
+function InputField({ className, ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
+  return <input className={twMerge(className, "bg-gray-300 text-black py-1 px-3 rounded-sm w-full text-lg")} {...props} />
+}
+
+const queryKey = ['units'];
+
+export default function ViewUnitPage() {
+
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const query = searchParams.get("q");
+
+  const { data: units, error, isFetched, isError, isLoading } = useQuery({
+    queryKey,
+    queryFn: () => {
+      console.log(`[QUERY] Querying page with ${query}`);
+      return [
+        { id: query ?? 0, name: "TEST" }
+      ] as Unit[];
+      // TODO: Integration with backend
+      // Endpoint.get("...")
+    },
+  })
+
+  const createQueryString = useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+      params.set(name, value)
+
+      return params.toString()
+    },
+    [searchParams]
+  )
+
+  const onSearch = useCallback((e: FormEvent<HTMLFormElement>) => {
+    const form = e.target as HTMLFormElement;
+    const id = (form.elements[0] as HTMLInputElement).value;
+
+    router.push(pathname + "?" + createQueryString("q", id));
+  }, []);
+
+  if (isError) console.error(error);
+
+  return (
+    <main className="w-full flex flex-col items-center gap-y-4 mr-2">
+      <form onSubmit={onSearch} className="flex flex-col items-center gap-y-2">
+        <h1 className="text-2xl my-2">Consultar Unidade</h1>
+
+        <label htmlFor="id" className="w-2xl">
+          <h1>ID:</h1>
+          <InputField name="id" id="id" placeholder="-" />
+        </label>
+
+        <button type="submit" className="bg-black text-white px-5 py-1 mt-2">
+          Buscar
+        </button>
+      </form>
+
+      <div className="w-full bg-gray-300 text-black p-5 min-h-50">
+        {isError && (
+          <div>
+            Houve um erro durante a chamada ao servidor.
+            Por favor, tente novamente.
+          </div>
+        )}
+
+        {isLoading && (
+          <div>
+            Carregando...
+          </div>
+        )}
+
+        {(isFetched && units?.length === 0) && (
+          <div>
+            Nenhuma unidade com o id informado foram encontradas
+          </div>
+        )}
+
+        {(isFetched && units!.length > 0) && (
+          <ul>
+            {units!.map(unit => (
+              <li key={unit.id}>
+                {unit.id} - {unit.name}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/frontend/app/(authed)/admin/unit/view/page.tsx
+++ b/frontend/app/(authed)/admin/unit/view/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Button } from "@/lib/components/button";
+import { InputField } from "@/lib/components/input";
 import { Unit } from "@/lib/schemas/unit";
 import { Endpoint } from "@/lib/services/endpoint";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -7,14 +9,9 @@ import { usePathname, useSearchParams, useRouter } from "next/navigation";
 import { FormEvent, useCallback } from "react";
 import { twMerge } from "tailwind-merge";
 
-function InputField({ className, ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
-  return <input className={twMerge(className, "bg-gray-300 text-black py-1 px-3 rounded-sm w-full text-lg")} {...props} />
-}
-
 const queryKey = ['units'];
 
 export default function ViewUnitPage() {
-
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -61,9 +58,9 @@ export default function ViewUnitPage() {
           <InputField name="id" id="id" placeholder="-" />
         </label>
 
-        <button type="submit" className="bg-black text-white px-5 py-1 mt-2">
+        <Button type="submit">
           Buscar
-        </button>
+        </Button>
       </form>
 
       <div className="w-full bg-gray-300 text-black p-5 min-h-50">

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import * as ReactQuery from "@/lib/config/react-query";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -23,7 +24,9 @@ export default function RootLayout({
       <body
         className={`${inter.className} antialiased`}
       >
-        {children}
+        <ReactQuery.Provider>
+          {children}
+        </ReactQuery.Provider>
       </body>
     </html>
   );

--- a/frontend/lib/components/button.tsx
+++ b/frontend/lib/components/button.tsx
@@ -1,0 +1,7 @@
+import { twMerge } from "tailwind-merge";
+
+export function Button({ className, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button {...props} className={twMerge(className, "bg-black text-white px-5 py-1 mt-3")} />
+  )
+}

--- a/frontend/lib/components/input.tsx
+++ b/frontend/lib/components/input.tsx
@@ -1,0 +1,6 @@
+import { twMerge } from "tailwind-merge";
+
+export function InputField({ className, ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
+  return <input className={twMerge(className, "bg-gray-300 text-black py-1 px-3 rounded-sm w-full text-lg")} {...props} />
+}
+

--- a/frontend/lib/components/layout/user.tsx
+++ b/frontend/lib/components/layout/user.tsx
@@ -11,7 +11,7 @@ export function UserLayout({ type, children }: PropsWithChildren<UserLayoutProps
     <div className="flex flex-row gap-x-2">
       <SideBarLayout type={type} />
 
-      <main className="flex-1 pt-1">
+      <main className="flex-1 pt-1 px-4">
         {children}
       </main>
     </div>

--- a/frontend/lib/config/react-query.tsx
+++ b/frontend/lib/config/react-query.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+    },
+  },
+});
+
+export function Provider({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}

--- a/frontend/lib/schemas/unit.ts
+++ b/frontend/lib/schemas/unit.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const Unit = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+
+export type Unit = z.infer<typeof Unit>;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,10 +8,12 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.77.0",
         "next": "15.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.2.0"
+        "tailwind-merge": "^3.2.0",
+        "zod": "^3.25.28"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2017,6 +2019,32 @@
         "lightningcss": "1.29.2",
         "postcss": "^8.4.41",
         "tailwindcss": "4.0.17"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.77.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.77.0.tgz",
+      "integrity": "sha512-PFeWjgMQjOsnxBwnW/TJoO0pCja2dzuMQoZ3Diho7dPz7FnTUwTrjNmdf08evrhSE5nvPIKeqV6R0fvQfmhGeg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.77.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.77.0.tgz",
+      "integrity": "sha512-jX52ot8WxWzWnAknpRSEWj6PTR/7nkULOfoiaVPk6nKu0otwt30UMBC9PTg/m1x0uhz1g71/imwjViTm/oYHxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.77.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4324,6 +4352,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.28",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.28.tgz",
+      "integrity": "sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,10 +11,12 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.77.0",
     "next": "15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.2.0"
+    "tailwind-merge": "^3.2.0",
+    "zod": "^3.25.28"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
Essa PR adiciona o layout apresentado no Figma sobre as rotas de unidade (`/admin/unit/view` e `/admin/unit/create`)

## Alterações:

 * Criação das rotas de unidade
 * Adição de [`@tanstack/query`](https://tanstack.com/query/) para query de conteudo
 * Adição de [`Zod`](https://zod.dev/) para criação de schemas/models

## Notas:

* Não se tem integração com o Backend, ou seja, todos os dados estão estáticos no momento
* Ainda se necessita melhorar a identidade visual das páginas
